### PR TITLE
0.2 fixes and upgrades

### DIFF
--- a/config.tfvars
+++ b/config.tfvars
@@ -3,12 +3,18 @@
 # GCP Project ID
 project_id = ""
 # The name you wish to have as a prefix for the deployment's resources. Must comply with [a-z]([-a-z0-9]*[a-z0-9])
-infra_name = ""
+infra_name = "scallops"
 
 #### Optional ####
 
 # Office IP / home IPs
 operator_ips = [""] 
+
+
+# Uncomment below 3 lines if wishing to supply external DNS name for accessing Gitalb instance
+#external_hostname = ""
+#dns_project_id = ""  # The project ID where the managed DNS zone is located
+#dns_managed_zone_name = "" # The configured managed DNS zone name
 
 
 # Default deployment values, uncommenct and modify only if needed (us-central-1 considered to be the cheapest).
@@ -19,3 +25,6 @@ operator_ips = [""]
 # zone = "a"
 # Region for the k8s cluster, Gitlab instance and network.
 # region = us-central-1 
+
+
+

--- a/gitlab-runner/kaniko-values.yaml
+++ b/gitlab-runner/kaniko-values.yaml
@@ -3,7 +3,6 @@ hostAliases:
  - ip: "10.0.0.2"
    hostnames:
     - "gitlab.local"
-locked: "true"
 rbac:
  create: true
  rules:
@@ -12,6 +11,7 @@ rbac:
   #  verbs: ["get", "list", "watch", "create", "patch", "delete", "update", "attach"]
 
 runners:
+  protected: true
   tags: "kaniko,kubernetes"
   config: |
     [[runners]]
@@ -19,7 +19,7 @@ runners:
       shell = "bash"
       
       [runners.kubernetes.node_selector]
-        "kubernetes.io/os" = "linux"
+        "node_pool" = "linux-pool"
 
       [runners.kubernetes]
         namespace = "sensitive"

--- a/gitlab-runner/kaniko-values.yaml
+++ b/gitlab-runner/kaniko-values.yaml
@@ -3,8 +3,7 @@ hostAliases:
  - ip: "10.0.0.2"
    hostnames:
     - "gitlab.local"
-locked: "false"
-logLevel: debug
+locked: "true"
 rbac:
  create: true
  rules:
@@ -13,7 +12,7 @@ rbac:
   #  verbs: ["get", "list", "watch", "create", "patch", "delete", "update", "attach"]
 
 runners:
-  tags: "linux,kubernetes"
+  tags: "kaniko,kubernetes"
   config: |
     [[runners]]
       executor = "kubernetes"
@@ -23,9 +22,13 @@ runners:
         "kubernetes.io/os" = "linux"
 
       [runners.kubernetes]
-        namespace = "default"
+        namespace = "sensitive"
         poll_interval = 30
         poll_timeout = 3600
         [[runners.kubernetes.host_aliases]]
           ip = "10.0.0.2"
           hostnames = ["gitlab.local"]
+        [[runners.kubernetes.volumes.secret]]
+          name = "kaniko-secret"
+          mount_path = "/secret"
+          read_only = true

--- a/gitlab-runner/linux-values.yaml
+++ b/gitlab-runner/linux-values.yaml
@@ -20,7 +20,7 @@ runners:
       shell = "bash"
       
       [runners.kubernetes.node_selector]
-        "kubernetes.io/os" = "linux"
+        "node_pool" = "linux-pool"
 
       [runners.kubernetes]
         namespace = "default"

--- a/gitlab-runner/win-values.yaml
+++ b/gitlab-runner/win-values.yaml
@@ -24,12 +24,13 @@ runners:
       # The FF_USE_POWERSHELL_PATH_RESOLVER feature flag has to be enabled for PowerShell 
       # to resolve paths for Windows correctly when Runner is operating in a Linux environment
       # but targeting Windows nodes.
-      environment = ["FF_USE_POWERSHELL_PATH_RESOLVER=1", "FF_USE_LEGACY_KUBERNETES_EXECUTION_STRATEGY=true"]
+      environment = ["FF_USE_POWERSHELL_PATH_RESOLVER=1"]
 
       [runners.kubernetes.node_selector]
-        "kubernetes.io/os" = "windows"
-        "node.kubernetes.io/windows-build" = "10.0.17763"
-        "kubernetes.io/arch" = "amd64"
+        "node_pool" = "windows-pool"
+
+      [runners.kubernetes.node_tolerations]
+        "node.kubernetes.io/os=windows" = "NoSchedule"
 
       [runners.kubernetes]
         namespace = "default"

--- a/iam.tf
+++ b/iam.tf
@@ -9,7 +9,7 @@ resource "google_service_account" "gitlab_service_account" {
 
 # Gitlab instance IAM Binding to storage
 resource "google_storage_bucket_iam_binding" "binding" {
-  bucket  = google_storage_bucket.gitlab_deploy_utils.name
+  bucket  = google_storage_bucket.deployment_utils.name
   role    = "roles/storage.objectViewer"
   members = [
     "serviceAccount:${google_service_account.gitlab_service_account.email}"

--- a/main.tf
+++ b/main.tf
@@ -2,7 +2,6 @@
 
 resource "google_compute_instance" "gitlab" {
   depends_on   = [
-                  module.gcp-network,
                   google_secret_manager_secret_version.gitlab-self-signed-cert-crt-version,
                   google_secret_manager_secret_version.gitlab-self-signed-cert-key-version,
                   google_secret_manager_secret_version.gitlab_initial_root_pwd,
@@ -30,20 +29,20 @@ resource "google_compute_instance" "gitlab" {
     }
 
     network_interface {
-      subnetwork = "${var.infra_name}-offensive-pipeline-subnet"
+      subnetwork = module.gcp-network.subnets_names[0]
       access_config {}
     }
 
 
   metadata = {
-    gcs-prefix                      = "gs://${google_storage_bucket.gitlab_deploy_utils.name}"
+    gcs-prefix                      = "gs://${google_storage_bucket.deployment_utils.name}"
     startup-script-url              = join("", [
-                                                "gs://", google_storage_bucket.gitlab_deploy_utils.name,
+                                                "gs://", google_storage_bucket.deployment_utils.name,
                                                 "/",
                                                 google_storage_bucket_object.gitlab_install_script.name
                                                 ])
-    cicd-utils-bucket-name          = google_storage_bucket.cicd_utils.name
-    instance-ext-domain             = local.instance_internal_domain
+    cicd-utils-bucket-name          = google_storage_bucket.deployment_utils.name
+    instance-internal-domain             = local.instance_internal_domain
     instance-protocol               = var.gitlab_instance_protocol
 	  gitlab-initial-root-pwd-secret	= google_secret_manager_secret.gitlab_initial_root_pwd.secret_id
     gitlab-api-token-secret         = google_secret_manager_secret.gitlab_api_token.secret_id
@@ -52,6 +51,7 @@ resource "google_compute_instance" "gitlab" {
     gitlab-ci-runner-registration-token-secret = google_secret_manager_secret.gitlab_runner_registration_token.secret_id
   }
 }
+
 
 
 
@@ -66,10 +66,44 @@ resource "helm_release" "gitlab-runner-linux" {
                 ]
   name       = "linux"
   # repository = "https://charts.gitlab.io/gitlab"
-  chart      = "https://gitlab.com/gitlab-org/charts/gitlab-runner/-/archive/v0.32.0/gitlab-runner-v0.32.0.tar.gz"
+  chart      = "https://gitlab-charts.s3.amazonaws.com/gitlab-runner-0.35.3.tgz"
   
   values     = [
     file("${path.module}/gitlab-runner/linux-values.yaml")
+    ]
+
+  set {
+    name  = "gitlabUrl"
+    value =  "${var.gitlab_instance_protocol}://${local.instance_internal_domain}"
+  }
+  set {
+    name  = "cloneUrl"
+    value =  "${var.gitlab_instance_protocol}://${local.instance_internal_domain}"
+  }
+  set {
+    name  = "certsSecretName"
+    value = "${local.instance_internal_domain}-cert"
+  }
+  set_sensitive {
+    name  = "runnerRegistrationToken"
+    value = random_password.gitlab_runner_registration_token.result
+  }
+}
+
+
+resource "helm_release" "gitlab-runner-kaniko" {
+  depends_on = [
+                module.gke,
+                module.gke_auth,
+                kubernetes_namespace.sensitive-namespace
+                ]
+  name       = "kaniko"
+  namespace  = "sensitive"
+  # repository = "https://charts.gitlab.io/gitlab"
+  chart      = "https://gitlab-charts.s3.amazonaws.com/gitlab-runner-0.35.3.tgz"
+  
+  values     = [
+    file("${path.module}/gitlab-runner/kaniko-values.yaml")
     ]
 
   set {
@@ -98,7 +132,7 @@ resource "helm_release" "gitlab-runner-win" {
                 ]
   name       = "windows"
   # repository = "https://charts.gitlab.io"
-  chart      = "https://gitlab.com/gitlab-org/charts/gitlab-runner/-/archive/v0.32.0/gitlab-runner-v0.32.0.tar.gz"
+  chart      = "https://gitlab-charts.s3.amazonaws.com/gitlab-runner-0.35.3.tgz"
   
   values     = [
     file("${path.module}/gitlab-runner/win-values.yaml")
@@ -137,14 +171,33 @@ resource "kubernetes_secret" "k8s_gitlab_cert_secret" {
 }
 
 
-resource "kubernetes_secret" "google-application-credentials" {
+resource "kubernetes_namespace" "sensitive-namespace" {
   depends_on  = [module.gke_auth, module.gke]
+  metadata {
+    annotations = {name = "Store Kaniko secret and pod runner"}
+    name = "sensitive"
+  }
+}
+
+resource "kubernetes_secret" "google-application-credentials" {
+  depends_on  = [module.gke_auth, module.gke, kubernetes_namespace.sensitive-namespace]
   data        = {
     "kaniko-token-secret.json" = base64decode(google_service_account_key.storage_admin_role.private_key)
   }
   metadata {
     name      = "kaniko-secret"
-    namespace = "default"
+    namespace = "sensitive"
+  }
+}
+
+resource "kubernetes_secret" "k8s_gitlab_cert_secret-sensitive" {
+  depends_on  = [module.gke_auth, module.gke]
+  data        = {
+    "${local.instance_internal_domain}.crt" = tls_self_signed_cert.gitlab-self-signed-cert.cert_pem
+  }
+  metadata {
+    name      = "${local.instance_internal_domain}-cert"
+    namespace = "sensitive"
   }
 }
 
@@ -157,32 +210,35 @@ module "gke_auth" {
   location     = module.gke.location
 }
 
+
 module "gke" {
-  depends_on                 = [module.gcp-network, google_compute_instance.gitlab]
+  depends_on                 = [google_compute_instance.gitlab]
   source                     = "terraform-google-modules/kubernetes-engine/google"
-  version                    = "15.0.0"
+  version                    = "17.3.0"
   project_id                 = var.project_id
-  name                       = "${var.infra_name}-offensive-pipeline-gke"
+  name                       = "${var.infra_name}-offensive-pipeline"
   regional                   = false
   region                     = var.region #Required if Regional true
   zones                      = ["${var.region}-${var.zone}"]
   network                    = module.gcp-network.network_name
-  subnetwork                 = "${var.infra_name}-offensive-pipeline-subnet"
-  default_max_pods_per_node  = 80
+  subnetwork                 = module.gcp-network.subnets_names[0]
+  default_max_pods_per_node  = 30
   ip_range_pods              = "${var.infra_name}-gke-pods-subnet"
   ip_range_services          = "${var.infra_name}-gke-service-subnet"
   http_load_balancing        = false
   horizontal_pod_autoscaling = true
   network_policy             = false
-  remove_default_node_pool   = false
-  initial_node_count         = 1
-
+# remove_default_node_pool   = true
+#  initial_node_count         = 1
+  create_service_account     = true
+  grant_registry_access      = true
+  
 
   node_pools = [
     {
       name                   = "linux-pool"
       machine_type           = "e2-medium"
-      min_count              = 0
+      min_count              = 1
       max_count              = 8
       local_ssd_count        = 0
       disk_size_gb           = 100
@@ -190,63 +246,28 @@ module "gke" {
       image_type             = "UBUNTU" // 20.04
       auto_repair            = false
       auto_upgrade           = false
-      service_account        = ""
-      preemptible            = false
-      initial_node_count     = 0
-    },
-    {
-      name                   = "windows-pool"
-      machine_type           = "n1-standard-2"
-      min_count              = 1
-      max_count              = 8
-      local_ssd_count        = 0
-      disk_size_gb           = 200
-      disk_type              = "pd-standard"
-      image_type             = "WINDOWS_LTSC" // 1809
-      auto_repair            = false
-      auto_upgrade           = false
-      service_account        = ""
       preemptible            = false
       initial_node_count     = 1
-    }    
+    }     
   ] 
 
   node_pools_oauth_scopes = {
-    all          = []
-    windows-pool = ["https://www.googleapis.com/auth/cloud-platform"]
+    all          = ["https://www.googleapis.com/auth/cloud-platform"]
   }
 
   node_pools_labels = {
     all          = {}
-    windows-pool = {windows = true}
   }
 
   node_pools_metadata = {
     all = {
       disable-legacy-endpoints = true
     }
-
-    windows-pool = {
-      windows                    = true,
-      windows-startup-script-url =  join("", [
-                                              "gs://", google_storage_bucket.cicd_utils.name,
-                                              "/",
-                                              google_storage_bucket_object.disable_windows_defender_ps.name
-                                              ])
-    }
   }
 
   node_pools_taints = {
     all          = []
-    windows-pool = [
-        {
-            key    = "node.kubernetes.io/os"
-            value  = "windows"
-            effect = "PREFER_NO_SCHEDULE"
-        }
-    ]
   }
-
   node_pools_tags = {
     all = []
   }

--- a/main.tf
+++ b/main.tf
@@ -41,8 +41,7 @@ resource "google_compute_instance" "gitlab" {
                                                 "/",
                                                 google_storage_bucket_object.gitlab_install_script.name
                                                 ])
-    cicd-utils-bucket-name          = google_storage_bucket.deployment_utils.name
-    instance-internal-domain             = local.instance_internal_domain
+    instance-external-domain             = var.external_hostname != "" ? var.external_hostname : local.instance_internal_domain
     instance-protocol               = var.gitlab_instance_protocol
 	  gitlab-initial-root-pwd-secret	= google_secret_manager_secret.gitlab_initial_root_pwd.secret_id
     gitlab-api-token-secret         = google_secret_manager_secret.gitlab_api_token.secret_id
@@ -50,6 +49,12 @@ resource "google_compute_instance" "gitlab" {
     gitlab-cert-public-secret	      = google_secret_manager_secret.gitlab-self-signed-cert-crt.secret_id
     gitlab-ci-runner-registration-token-secret = google_secret_manager_secret.gitlab_runner_registration_token.secret_id
   }
+lifecycle {
+    ignore_changes = [
+        metadata,
+    ]
+  }
+
 }
 
 

--- a/network.tf
+++ b/network.tf
@@ -56,3 +56,18 @@ resource "google_compute_firewall" "pods-to-gitlab-access" {
     ports    = var.operator_ports
   }
 }
+
+
+
+# DNS Record
+
+resource "google_dns_record_set" "ext-dns" {
+  provider = google.dns_infra
+  count   = var.external_hostname != "" ? 1 : 0
+  name = var.external_hostname
+  type = "A"
+  ttl  = var.dns_record_ttl
+  managed_zone = var.dns_managed_zone_name
+  rrdatas = [google_compute_instance.gitlab.network_interface.0.access_config.0.nat_ip]
+}
+

--- a/network.tf
+++ b/network.tf
@@ -64,7 +64,7 @@ resource "google_compute_firewall" "pods-to-gitlab-access" {
 resource "google_dns_record_set" "ext-dns" {
   provider = google.dns_infra
   count   = var.external_hostname != "" ? 1 : 0
-  name = var.external_hostname
+  name = "${var.external_hostname}."
   type = "A"
   ttl  = var.dns_record_ttl
   managed_zone = var.dns_managed_zone_name

--- a/provider.tf
+++ b/provider.tf
@@ -3,6 +3,11 @@ provider "google" {
     project = var.project_id
 }
 
+provider "google" {
+    alias   = "dns_infra"
+    project = var.dns_project_id
+}
+
 provider "kubernetes" {
   host                   = module.gke_auth.host
   token                  = module.gke_auth.token

--- a/scripts/bash/gitlab_install.sh
+++ b/scripts/bash/gitlab_install.sh
@@ -23,7 +23,7 @@ sudo apt-get install -y curl ca-certificates tzdata perl jq
 ## Network variables
 INSTANCE_PROTOCOL=`curl -H "Metadata-Flavor: Google" http://169.254.169.254/computeMetadata/v1/instance/attributes/instance-protocol` #http/https
 echo "INFO: Protocol is $INSTANCE_PROTOCOL"
-INSTANCE_EXTERNAL_DOMAIN=`curl -H "Metadata-Flavor: Google" http://169.254.169.254/computeMetadata/v1/instance/attributes/instance-ext-domain`
+INSTANCE_EXTERNAL_DOMAIN=`curl -H "Metadata-Flavor: Google" http://169.254.169.254/computeMetadata/v1/instance/attributes/instance-internal-domain`
 echo "INFO: domain name is $INSTANCE_EXTERNAL_DOMAIN"
 EXTERNAL_IP=`curl -H "Metadata-Flavor: Google" http://metadata/computeMetadata/v1/instance/network-interfaces/0/access-configs/0/external-ip`
 echo "INFO: external IP is $EXTERNAL_IP"
@@ -147,3 +147,9 @@ then
 else
     echo "INFO: SCALLOPS-RECIPES Import failed or still in-progress, you can trigger the pipline manually."
 fi
+
+
+# Remove startup script reference (prevent from running on rebbot)
+name=`curl -H "Metadata-Flavor: Google" http://169.254.169.254/computeMetadata/v1/instance/name`
+zone=`curl -H "Metadata-Flavor: Google" http://169.254.169.254/computeMetadata/v1/instance/zone | cut -d'/' -f 4`
+gcloud compute instances remove-metadata "$name" --zone="$zone" --keys=startup-script-url

--- a/scripts/bash/gitlab_install.sh
+++ b/scripts/bash/gitlab_install.sh
@@ -15,7 +15,7 @@ fi
 # Install Dependencies
 sudo apt-get update
 # sudo apt-get install -y curl openssh-server ca-certificates tzdata perl jq
-sudo apt-get install -y curl ca-certificates tzdata perl jq
+sudo apt-get install -y curl ca-certificates tzdata perl jq coreutils zip
 
 
 
@@ -23,7 +23,7 @@ sudo apt-get install -y curl ca-certificates tzdata perl jq
 ## Network variables
 INSTANCE_PROTOCOL=`curl -H "Metadata-Flavor: Google" http://169.254.169.254/computeMetadata/v1/instance/attributes/instance-protocol` #http/https
 echo "INFO: Protocol is $INSTANCE_PROTOCOL"
-INSTANCE_EXTERNAL_DOMAIN=`curl -H "Metadata-Flavor: Google" http://169.254.169.254/computeMetadata/v1/instance/attributes/instance-internal-domain`
+INSTANCE_EXTERNAL_DOMAIN=`curl -H "Metadata-Flavor: Google" http://169.254.169.254/computeMetadata/v1/instance/attributes/instance-external-domain`
 echo "INFO: domain name is $INSTANCE_EXTERNAL_DOMAIN"
 EXTERNAL_IP=`curl -H "Metadata-Flavor: Google" http://metadata/computeMetadata/v1/instance/network-interfaces/0/access-configs/0/external-ip`
 echo "INFO: external IP is $EXTERNAL_IP"
@@ -36,14 +36,16 @@ GITLAB_API_TOKEN=`gcloud secrets versions access latest --secret=$GITLAB_API_TOK
 GITLAB_RUNNER_REG_SECRET=`curl -H "Metadata-Flavor: Google" http://169.254.169.254/computeMetadata/v1/instance/attributes/gitlab-ci-runner-registration-token-secret`
 GITLAB_RUNNER_REG=`gcloud secrets versions access latest --secret=$GITLAB_RUNNER_REG_SECRET`
 
+
 ## Post installation required variables
 GCP_PROJECT_ID=`gcloud config list --format 'value(core.project)' 2>/dev/null`
-CI_CD_UTILS_BUKCET=`curl -H "Metadata-Flavor: Google" http://169.254.169.254/computeMetadata/v1/instance/attributes/cicd-utils-bucket-name`
+GITLAB_READ_API=$(echo $RANDOM | md5sum | head -c 16)
 
 
 EXTERNAL_URL="$INSTANCE_PROTOCOL://$INSTANCE_EXTERNAL_DOMAIN"
 echo "INFO: external URL will be $EXTERNAL_URL"
 
+############### Gitlab Installation ##############
 
 # Install Postfix non-interactive
 echo "INFO: Starting postfix installation"
@@ -82,6 +84,7 @@ fi
 #Create personal token for the root account
 echo "INFO: Seeding personal token for root account"
 sudo gitlab-rails runner "token = User.find_by_username('root').personal_access_tokens.create(scopes: [:api], name: 'Gitlab post deployment script'); token.set_token('$GITLAB_API_TOKEN'); token.save!"
+sudo gitlab-rails runner "token = User.find_by_username('root').personal_access_tokens.create(scopes: [:read_api], name: 'Gitlab Fetch previous artifacts'); token.set_token('$GITLAB_READ_API'); token.save!"
 
 
 # TBD Create all actions below via gitlab-rails
@@ -91,8 +94,11 @@ sleep 120
 # Set instance level environment variables, so pipelines can utilize them
 echo "INFO: Setting instance level CI/CD variables"
 curl -X POST -k -H "PRIVATE-TOKEN: $GITLAB_API_TOKEN" "https://localhost/api/v4/admin/ci/variables" --form "key=GCP_PROJECT_ID" --form "value=$GCP_PROJECT_ID"
-curl -o /dev/null -X POST -k -H "PRIVATE-TOKEN: $GITLAB_API_TOKEN" "https://localhost/api/v4/admin/ci/variables" --form "key=GITLAB_API_ACCESS" --form "value=$GITLAB_API_TOKEN" --form "masked=true"
-curl -X POST -k -H "PRIVATE-TOKEN: $GITLAB_API_TOKEN" "https://localhost/api/v4/admin/ci/variables" --form "key=CI_CD_UTILS_BUKCET" --form "value=$CI_CD_UTILS_BUKCET"
+curl -o /dev/null -X POST -k -H "PRIVATE-TOKEN: $GITLAB_API_TOKEN" "https://localhost/api/v4/admin/ci/variables" --form "key=GITLAB_READ_API" --form "value=$GITLAB_READ_API" --form "masked=true"
+
+#TBD Change to recipes project level
+curl -o /dev/null -X POST -k -H "PRIVATE-TOKEN: $GITLAB_API_TOKEN" "https://localhost/api/v4/admin/ci/variables" --form "key=GITLAB_API_ACCESS" --form "value=$GITLAB_API_TOKEN" --form "masked=true" --form "protected=true"
+
 
 
 

--- a/secrets.tf
+++ b/secrets.tf
@@ -20,7 +20,7 @@ resource "tls_self_signed_cert" "gitlab-self-signed-cert" {
   dns_names             = [
                            "${var.infra_name}-gitlab.local",
                            local.instance_internal_domain,
-                           var.instance_ext_domain
+                           var.external_hostname
                            ]
   ip_addresses          = ["10.0.0.2"]
   validity_period_hours = 87600 //Certificate will be valid for 10 years 

--- a/storage.tf
+++ b/storage.tf
@@ -1,32 +1,30 @@
 # CICD utilities Storage
 
-resource "google_storage_bucket" "cicd_utils" {
-  name                        = "${var.infra_name}-cicd-utils"
+resource "random_string" "deployment_utils_bucket_suffix" {
+  length           = 4
+  special          = false
+  lower            = true
+  upper            = false
+}
+
+resource "google_storage_bucket" "deployment_utils" {
+  name                        = "${var.infra_name}-utils-${random_string.deployment_utils_bucket_suffix.result}"
   location                    = "US"
   storage_class               = "STANDARD"
   uniform_bucket_level_access = true
   provider                    = google.offensive-pipeline
 }
 
+
 resource "google_storage_bucket_object" "disable_windows_defender_ps" {
   name   = "scripts/Powershell/disabledefender.ps1"
-  bucket = google_storage_bucket.cicd_utils.name
+  bucket = google_storage_bucket.deployment_utils.name
   source = "${path.module}/scripts/Powershell/disabledefender.ps1"
 }
 
 
-# Gitlab instance deploy storage
-
-resource "google_storage_bucket" "gitlab_deploy_utils" {
-  name                        = "${var.infra_name}-gitlab-deploy-utils"
-  location                    = "US"
-  storage_class               = "STANDARD"
-  uniform_bucket_level_access = true
-  provider                    = google.offensive-pipeline
-}
-
 resource "google_storage_bucket_object" "gitlab_install_script" {
   name   = "scripts/bash/gitlab_install.sh"
-  bucket = google_storage_bucket.gitlab_deploy_utils.name
+  bucket = google_storage_bucket.deployment_utils.name
   source = "${path.module}/scripts/bash/gitlab_install.sh"
 }

--- a/vars.tf
+++ b/vars.tf
@@ -4,6 +4,12 @@ variable "project_id" {
     description = "(required) GCP Project ID to deploy to"
 }
 
+variable "dns_project_id" {
+    type        = string
+    description = "If provided external_hostname, specify GCP Project ID where managed zone is located"
+    default     = ""
+}
+
 variable "infra_name" {
     type        = string
     description = "(required) Infrastructure name or Team name" 
@@ -15,12 +21,6 @@ variable "infra_name" {
 
 
 # Gitlab instance related variables
-variable "instance_ext_domain" {
-    type        = string
-    description = "(optional) External domain for the Gitlab instance" //Doesn't affect the deploynment yet
-    default     = "gitlab.local"  // Don't leave it empty. Certificate creation will be failed without errors!
-}
-
 
 variable "gitlab_instance_protocol" {
     type        = string
@@ -85,3 +85,26 @@ variable "zone" {
     description = "(optional) Zone in which Gitlab GCE and K8s cluster will be deployed, K8s cluster will be Zonal and not Regional."
     default     = "a"
 }
+
+
+
+
+# DNS and managed zone variables
+variable "external_hostname" {
+  description = "The external hostname to be configured for the instance. e.g. scallops.example.com"
+  type        = string
+  default     = ""
+}
+
+variable "dns_managed_zone_name" {
+  description = "The name of the Cloud DNS Managed Zone in which to create the DNS A Records specified in external_hostname. Only use if provided external_hostname. e.g. example-com"
+  type        = string
+  default     = ""
+}
+
+variable "dns_record_ttl" {
+  description = "The time-to-live for the site A records (seconds)"
+  type        = number
+  default     = 300
+}
+

--- a/windows-pool.tf
+++ b/windows-pool.tf
@@ -64,7 +64,7 @@ resource "google_container_node_pool" "windows-pool" {
               effect = "NO_SCHEDULE"
               key    = "node.kubernetes.io/os"
               value  = "windows"
-            },
+            }
           ]
 
       shielded_instance_config {

--- a/windows-pool.tf
+++ b/windows-pool.tf
@@ -1,0 +1,91 @@
+resource "google_container_node_pool" "windows-pool" {
+  depends_on          = [module.gke,
+                         helm_release.gitlab-runner-linux,
+                         helm_release.gitlab-runner-win,
+                         helm_release.gitlab-runner-kaniko
+                         ]
+  cluster             = module.gke.cluster_id
+  initial_node_count  = 0
+  location            = "${var.region}-${var.zone}"
+  max_pods_per_node   = 10
+  name                = "windows-pool"
+  node_count          = 0
+  node_locations      = ["${var.region}-${var.zone}"]
+  project             = var.project_id
+  version             = "1.21.6-gke.1500" #Make upgrades from here.
+  autoscaling {
+      max_node_count = 8
+      min_node_count = 0
+    }
+
+  management {
+      auto_repair  = false
+      auto_upgrade = false
+    }
+
+  node_config {
+      disk_size_gb      = 200
+      disk_type         = "pd-standard"
+      guest_accelerator = []
+      image_type        = "WINDOWS_LTSC"
+      labels            = {
+          "cluster_name" = module.gke.name
+          "node_pool"    = "windows-pool"
+          "windows"      = "true"
+        }
+      local_ssd_count   = 0
+      machine_type      = "n1-standard-2"
+      metadata          = {
+          "cluster_name"               = module.gke.name
+          "disable-legacy-endpoints"   = "true"
+          "node_pool"                  = "windows-pool"
+          "windows"                    = "true"
+          "windows-startup-script-url" = join("", [
+                                              "gs://", google_storage_bucket.deployment_utils.name,
+                                              "/",
+                                              google_storage_bucket_object.disable_windows_defender_ps.name
+                                              ])
+        }
+      oauth_scopes      = ["https://www.googleapis.com/auth/cloud-platform"]
+      preemptible       = false
+      service_account   = module.gke.service_account
+      tags              = [
+                           join("", ["gke-", var.infra_name, "-offensive-pipeline"]), 
+                           join("", ["gke-", var.infra_name, "-offensive-pipeline-windows-pool"])
+
+          ]
+      taint             = [
+          {
+              effect = "PREFER_NO_SCHEDULE"
+              key    = "node.kubernetes.io/os"
+              value  = "windows"
+            },
+          {
+              effect = "NO_SCHEDULE"
+              key    = "node.kubernetes.io/os"
+              value  = "windows"
+            },
+          ]
+
+      shielded_instance_config {
+        enable_integrity_monitoring = true
+        enable_secure_boot          = false
+        }
+
+      workload_metadata_config {
+        mode          = "GKE_METADATA"
+        node_metadata = "GKE_METADATA_SERVER"
+        }
+    }
+
+  timeouts {
+    create = "45m"
+    delete = "45m"
+    update = "45m"
+    }
+
+  upgrade_settings {
+    max_surge       = 1
+    max_unavailable = 0
+    }
+}


### PR DESCRIPTION
- Added support for providing external DNS hostname that is managed via Google Cloud DNS
- Created additional gitlab-runner (on new k8s namespace) to secure the container build and push process, and also the storage credentials.
- Removed unnecessary variables from helm charts values.
- Added service account binding to the Gitlab instance
   - Added access to the compute metadata so it can remove its startup script after completing execution.
 - Separated windows-pool from the GKE module into a single resource, to better manage specific changes 
 - Unified deployment buckets into one bucket only.