### PR TITLE
Added backup capability

### DIFF
--- a/config.tfvars
+++ b/config.tfvars
@@ -4,6 +4,7 @@
 project_id = ""
 # The name you wish to have as a prefix for the deployment's resources. Must comply with [a-z]([-a-z0-9]*[a-z0-9])
 infra_name = "scallops"
+backups_bucket_name = "" # The name of an existing bucket you wish to receive backups to. Terraform will create the required permission to upload the backup archive.
 
 #### Optional ####
 

--- a/main.tf
+++ b/main.tf
@@ -49,6 +49,8 @@ resource "google_compute_instance" "gitlab" {
     gitlab-cert-key-secret         	= google_secret_manager_secret.gitlab-self-signed-cert-key.secret_id
     gitlab-cert-public-secret	    = google_secret_manager_secret.gitlab-self-signed-cert-crt.secret_id
     gitlab-ci-runner-registration-token-secret = google_secret_manager_secret.gitlab_runner_registration_token.secret_id
+    gitlab-backup-key-secret        = google_secret_manager_secret.gitlab_backup_key.secret_id
+    gitlab-backup-bucket-name       = var.backups_bucket_name
   }
 lifecycle {
     ignore_changes = [

--- a/scripts/bash/gitlab_backup.sh
+++ b/scripts/bash/gitlab_backup.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+
+
+### Scallops customized Gitlab backup script ###
+## Run as root/sudo
+
+TIMESTAMP=`date +"%s"`
+INSTANCE_NAME=`curl -H "Metadata-Flavor: Google" http://169.254.169.254/computeMetadata/v1/instance/name`
+BACKUP_LOG_FILE="$INSTANCE_NAME-$TIMESTAMP-backup.log"
+
+echo "INFO: Starting backup - $TIMESTAMP" >> $BACKUP_LOG_FILE
+
+# Stop Gitlab services
+echo "INFO: Stopping Gitlab services (unicorn, sidekiq, puma)..." >> $BACKUP_LOG_FILE
+gitlab-ctl stop unicorn >> $BACKUP_LOG_FILE
+gitlab-ctl stop sidekiq >> $BACKUP_LOG_FILE
+gitlab-ctl stop puma >> $BACKUP_LOG_FILE
+
+# Create back up TAR
+echo "INFO: Creaing back tar file" >> $BACKUP_LOG_FILE
+gitlab-backup create >> $BACKUP_LOG_FILE
+
+# Restart Gitlab services back
+echo "INFO: Restarting gitlab services" >> $BACKUP_LOG_FILE
+gitlab-ctl restart >> $BACKUP_LOG_FILE
+
+
+# Create backup folder
+
+BACKUP_DIR="backup-$TIMESTAMP"
+mkdir -p $BACKUP_DIR
+
+
+# Copy DB backup and configurations
+echo "INFO: Locating latest backup tar..." >> $BACKUP_LOG_FILE
+MOST_RECENT_BACKUP_NAME=`sudo ls -t /var/opt/gitlab/backups/ | head -1`
+echo "INFO: Using backup: $MOST_RECENT_BACKUP_NAME" >> $BACKUP_LOG_FILE
+
+echo "INFO: Copying DB backup, gitlab configurations and SSL ceritficates" >> $BACKUP_LOG_FILE
+cp /var/opt/gitlab/backups/$MOST_RECENT_BACKUP_NAME $BACKUP_DIR/  >> $BACKUP_LOG_FILE
+cp /etc/gitlab/gitlab.rb $BACKUP_DIR/ >> $BACKUP_LOG_FILE
+cp /etc/gitlab/gitlab-secrets.json $BACKUP_DIR/ >> $BACKUP_LOG_FILE
+cp -R /etc/gitlab/ssl/ $BACKUP_DIR/ >> $BACKUP_LOG_FILE
+
+
+# Get the backup archive password
+echo "INFO: Fetching backup archive password from secrets" >> $BACKUP_LOG_FILE
+GITLAB_BACKUP_PASSWORD_SECRET=`curl -H "Metadata-Flavor: Google" http://169.254.169.254/computeMetadata/v1/instance/attributes/gitlab-backup-key-secret`
+GITLAB_BACKUP_PASSWORD=`gcloud secrets versions access latest --secret=$GITLAB_BACKUP_PASSWORD_SECRET`
+
+
+# Get the backup bucket name
+echo "INFO: Fetching backup target bucket" >> $BACKUP_LOG_FILE
+GITLAB_BACKUPS_BUCKET_NAME=`curl -H "Metadata-Flavor: Google" http://169.254.169.254/computeMetadata/v1/instance/attributes/gitlab-backup-bucket-name`
+
+
+# Archive and encrypt backup
+echo "INFO: Archiving and encrypting backup..." >> $BACKUP_LOG_FILE
+7z a -p$GITLAB_BACKUP_PASSWORD $BACKUP_DIR.zip ./$BACKUP_DIR/*  >> $BACKUP_LOG_FILE
+
+# Upload archived backup
+echo "INFO: Uploading backup as: gs://$GITLAB_BACKUPS_BUCKET_NAME/gitlab-backups/$INSTANCE_NAME-$BACKUP_DIR.zip" >> $BACKUP_LOG_FILE
+gsutil cp $BACKUP_DIR.zip gs://$GITLAB_BACKUPS_BUCKET_NAME/gitlab-backups/$INSTANCE_NAME-$BACKUP_DIR.zip >> $BACKUP_LOG_FILE
+
+
+# Delete source directory and backup archive
+echo "INFO: Deleting processed files..." >> $BACKUP_LOG_FILE
+rm -r $BACKUP_DIR
+rm $BACKUP_DIR.zip
+
+ls -la >> $BACKUP_LOG_FILE
+echo "INFO: Backup completed!" >> $BACKUP_LOG_FILE
+
+gsutil cp $BACKUP_LOG_FILE gs://$GITLAB_BACKUPS_BUCKET_NAME/gitlab-backups/$BACKUP_LOG_FILE
+yes | rm $BACKUP_LOG_FILE

--- a/scripts/bash/gitlab_backup_exec.sh
+++ b/scripts/bash/gitlab_backup_exec.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin"
+
+DEPLOYMENT_GCS_PREFIX=`curl -H "Metadata-Flavor: Google" http://169.254.169.254/computeMetadata/v1/instance/attributes/gcs-prefix`
+gsutil cp $DEPLOYMENT_GCS_PREFIX/scripts/bash/gitlab_backup.sh ./gitlab_backup.sh
+chmod +x gitlab_backup.sh
+sudo ./gitlab_backup.sh

--- a/scripts/bash/gitlab_install.sh
+++ b/scripts/bash/gitlab_install.sh
@@ -167,3 +167,12 @@ fi
 name=`curl -H "Metadata-Flavor: Google" http://169.254.169.254/computeMetadata/v1/instance/name`
 zone=`curl -H "Metadata-Flavor: Google" http://169.254.169.254/computeMetadata/v1/instance/zone | cut -d'/' -f 4`
 gcloud compute instances remove-metadata "$name" --zone="$zone" --keys=startup-script-url
+
+
+# Download backup cron executor and cron job #Backup will occur every Saturday on 10:00 UTC
+DEPLOYMENT_GCS_PREFIX=`curl -H "Metadata-Flavor: Google" http://169.254.169.254/computeMetadata/v1/instance/attributes/gcs-prefix`
+sudo gsutil cp $DEPLOYMENT_GCS_PREFIX/scripts/bash/gitlab_backup_exec.sh /gitlab_backup_exec.sh
+sudo chmod +x /gitlab_backup_exec.sh
+echo "0 10 * * 6 /gitlab_backup_exec.sh" > gitlab-backup-cron
+sudo crontab gitlab-backup-cron
+rm gitlab-backup-cron

--- a/scripts/bash/gitlab_migrate.sh
+++ b/scripts/bash/gitlab_migrate.sh
@@ -169,3 +169,12 @@ echo "INFO: Removing startup-script-url from metadata..."
 gcloud compute instances remove-metadata "$name" --zone="$zone" --keys=startup-script-url
 echo "INFO: Removing migrated-gitlab-backup-password from metadata..."
 gcloud compute instances remove-metadata "$name" --zone="$zone" --keys=migrated-gitlab-backup-password
+
+
+# Download backup cron executor and cron job #Backup will occur every Saturday on 10:00 UTC
+DEPLOYMENT_GCS_PREFIX=`curl -H "Metadata-Flavor: Google" http://169.254.169.254/computeMetadata/v1/instance/attributes/gcs-prefix`
+sudo gsutil cp $DEPLOYMENT_GCS_PREFIX/scripts/bash/gitlab_backup_exec.sh /gitlab_backup_exec.sh
+sudo chmod +x /gitlab_backup_exec.sh
+echo "0 10 * * 6 /gitlab_backup_exec.sh" > gitlab-backup-cron
+sudo crontab gitlab-backup-cron
+rm gitlab-backup-cron

--- a/secrets.tf
+++ b/secrets.tf
@@ -98,6 +98,11 @@ resource "random_password" "gitlab_api_token" {
   override_special = "-_"
 }
 
+resource "random_password" "gitlab_backup_key" {
+  length           = 24
+  special          = true
+  override_special = "-_"
+}
 
 # Gitlab runner registration token
 
@@ -167,4 +172,28 @@ resource "google_secret_manager_secret" "gitlab_api_token" {
 resource "google_secret_manager_secret_version" "gitlab_api_token" {
   secret      = google_secret_manager_secret.gitlab_api_token.id
   secret_data = random_password.gitlab_api_token.result
+}
+
+
+# Gitlab backup archives password
+
+resource "google_secret_manager_secret" "gitlab_backup_key" {
+  project    = var.project_id
+  secret_id  = "${var.infra_name}-gitlab-backup-key"
+  labels     = {
+          label = "gitlab"
+  }
+  replication {
+    user_managed {
+          replicas {
+            location = var.region
+      }
+    }
+  }
+}
+
+
+resource "google_secret_manager_secret_version" "gitlab_backup_key" {
+  secret      = google_secret_manager_secret.gitlab_backup_key.id
+  secret_data = random_password.gitlab_backup_key.result
 }

--- a/storage.tf
+++ b/storage.tf
@@ -29,6 +29,19 @@ resource "google_storage_bucket_object" "gitlab_install_script" {
   source = "${path.module}/scripts/bash/gitlab_install.sh"
 }
 
+# Customized Gitlab backup script
+
+resource "google_storage_bucket_object" "gitlab_backup_script" {
+  name   = "scripts/bash/gitlab_backup.sh"
+  bucket = google_storage_bucket.deployment_utils.name
+  source = "${path.module}/scripts/bash/gitlab_backup.sh"
+}
+
+resource "google_storage_bucket_object" "gitlab_backup_script_exec" {
+  name   = "scripts/bash/gitlab_backup_exec.sh"
+  bucket = google_storage_bucket.deployment_utils.name
+  source = "${path.module}/scripts/bash/gitlab_backup_exec.sh"
+}
 
 # Migration resource
 

--- a/vars.tf
+++ b/vars.tf
@@ -19,6 +19,12 @@ variable "infra_name" {
     }
 }
 
+# Backup variables
+variable "backups_bucket_name" {
+    type        = string
+    description = "The name of the bucket backups are stored. Bucket must exist before apply. Terrafrom will add objectCreator permission to the gitlab svc account."
+}
+
 # Migration variables 
 variable "migrate_gitlab" {
     type        = bool


### PR DESCRIPTION
* Deployers now need to specify an existing bucket they created beforehand to keep their Gitlab data backups. Backup bucket is required and has to be supplied using backups_bucket_name via config.tfvars.

* Terraform will create specific role that will be attached to Gitlab instance SVC account and allow it to only create new backups on the supplied bucket. Gitlab svc account wont be able to read other/previous backups or delete them.

* Gitlab installation and migration scripts create cronjob that will execute the backup process on a weekly basis (every Saturday on 10AM UTC).
* The backup bash script is pulled from the deployment bucket every time so it will be convenient to make changes to the process without interacting with the instance.
* The backup process log is also uploaded to the designated bucket on every backup process.

* Backup archive is encrypted with a password generated by TF and stored within the secret manager. 
* Backup archive contains the following:
    * gitlab-backup.tar  (File containing the DB)
    * gitlab.rb (Main gitlab configuration file)
    * gitlab-secret.json (A file containing keys to the DB encrypted data)
    * ssl/hostname.key (SSL cert private key belonging to the existing hostname)
    * ssl/hostname.cer (SSL pub certificate belonging to the existing hostname)

*Note that this backup structure works perfectly with the migration and restore capability created in this repository

