### PR TITLE
Modified project Ids to provider variable

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -4,7 +4,7 @@
 resource "google_service_account" "gitlab_service_account" {
   account_id   = "${var.infra_name}-gitlab-svc"
   display_name = "Gitlab Service Account"
-  project      = var.project_id
+  provider     = google.offensive-pipeline
 }
 
 resource "google_project_iam_binding" "sa_binding" {
@@ -75,13 +75,13 @@ resource "google_project_iam_binding" "compute_binding" {
 resource "google_service_account" "gke_bucket_service_account" {
   account_id   = "${var.infra_name}-gke-buckt"
   display_name = "GKE Service Account for Pods to access buckets, push and pull containers"
-  project      = var.project_id
+  provider     = google.offensive-pipeline
 }
 
 resource "google_project_iam_member" "storage_admin_role" {
-  role    = "roles/storage.admin"
-  member  = "serviceAccount:${google_service_account.gke_bucket_service_account.email}"
-  project = var.project_id
+  role      = "roles/storage.admin"
+  member    = "serviceAccount:${google_service_account.gke_bucket_service_account.email}"
+  provider  = google.offensive-pipeline
 }
 
 resource "google_service_account_key" "storage_admin_role" {

--- a/secrets.tf
+++ b/secrets.tf
@@ -35,7 +35,7 @@ resource "tls_self_signed_cert" "gitlab-self-signed-cert" {
 # Gitlab server certificate
 
 resource "google_secret_manager_secret" "gitlab-self-signed-cert-key" {
-  project    = var.project_id
+  provider   = google.offensive-pipeline
   secret_id  = "${var.infra_name}-gitlab-cert-key"
   labels     = {
         label = "gitlab-cert"
@@ -57,7 +57,7 @@ resource "google_secret_manager_secret_version" "gitlab-self-signed-cert-key-ver
 
 
 resource "google_secret_manager_secret" "gitlab-self-signed-cert-crt" {
-  project    = var.project_id
+  provider   = google.offensive-pipeline
   secret_id  = "${var.infra_name}-gitlab-cert-crt"
   labels     = {
           label = "gitlab-cert"
@@ -107,7 +107,7 @@ resource "random_password" "gitlab_backup_key" {
 # Gitlab runner registration token
 
 resource "google_secret_manager_secret" "gitlab_runner_registration_token" {
-  project    = var.project_id
+  provider   = google.offensive-pipeline
   secret_id  = "${var.infra_name}-gitlab-runner-reg"
   labels     = {
           label = "gitlab"
@@ -130,7 +130,7 @@ resource "google_secret_manager_secret_version" "gitlab_runner_registration_toke
 
 # Gitlab initial root password
 resource "google_secret_manager_secret" "gitlab_initial_root_pwd" {
-  project    = var.project_id
+  provider   = google.offensive-pipeline
   secret_id  = "${var.infra_name}-gitlab-root-password"
   labels     = {
           label = "gitlab"
@@ -154,7 +154,7 @@ resource "google_secret_manager_secret_version" "gitlab_initial_root_pwd" {
 # Gitlab root account personal access token (API)
 
 resource "google_secret_manager_secret" "gitlab_api_token" {
-  project    = var.project_id
+  provider   = google.offensive-pipeline
   secret_id  = "${var.infra_name}-gitlab-api-token"
   labels     = {
           label = "gitlab"
@@ -178,7 +178,7 @@ resource "google_secret_manager_secret_version" "gitlab_api_token" {
 # Gitlab backup archives password
 
 resource "google_secret_manager_secret" "gitlab_backup_key" {
-  project    = var.project_id
+  provider   = google.offensive-pipeline
   secret_id  = "${var.infra_name}-gitlab-backup-key"
   labels     = {
           label = "gitlab"

--- a/windows-pool.tf
+++ b/windows-pool.tf
@@ -11,7 +11,7 @@ resource "google_container_node_pool" "windows-pool" {
   name                = "windows-pool"
   #node_count          = 0
   node_locations      = ["${var.region}-${var.zone}"]
-  project             = var.project_id
+  provider            = google.offensive-pipeline
   version             = "1.20.9-gke.1001" #Make upgrades from here.
   autoscaling {
       max_node_count = 8


### PR DESCRIPTION
This does not applied to TF modules (GKE, GKE_AUTH, GCP_NETWORK) as project_id variable was required in them.