### PR TITLE
Scoped bucket admin permissions to container registry bucket only

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -78,11 +78,15 @@ resource "google_service_account" "gke_bucket_service_account" {
   provider     = google.offensive-pipeline
 }
 
-resource "google_project_iam_member" "storage_admin_role" {
-  role      = "roles/storage.admin"
-  member    = "serviceAccount:${google_service_account.gke_bucket_service_account.email}"
+resource "google_storage_bucket_iam_binding" "containeradmin_binding" {
+  bucket  = "artifacts.${var.project_id}.appspot.com"  # Default prefix-suffix for container registry bucket
   provider  = google.offensive-pipeline
+  role      = "roles/storage.admin"
+  members = [
+    "serviceAccount:${google_service_account.gke_bucket_service_account.email}"
+  ]
 }
+
 
 resource "google_service_account_key" "storage_admin_role" {
   service_account_id = google_service_account.gke_bucket_service_account.name


### PR DESCRIPTION
artifacts.<PROJECT-ID>.appspot.com is the default bucket name where GCP stores container images used by GKE.
Scoped the permissions of the service account that is in use with Kaniko to administer only that bucket.