### PR TITLE
Fixed bug when GKE won't scale down linux nodes

### DIFF
--- a/gke.tf
+++ b/gke.tf
@@ -84,7 +84,7 @@ module "gke" {
   node_pools = [
     {
       name                   = "linux-pool"
-      machine_type           = "e2-medium"
+      machine_type           = "e2-highcpu-2"
       min_count              = 1
       max_count              = 8
       local_ssd_count        = 0

--- a/gke.tf
+++ b/gke.tf
@@ -211,3 +211,38 @@ resource "google_container_node_pool" "windows-pool" {
     max_unavailable = 0
     }
 }
+
+resource "kubernetes_pod_disruption_budget" "kube-dns" {
+  depends_on  = [module.gke]
+  metadata {
+    name      = "k8s-pdb-kube-dns"
+    namespace = "kube-system"
+  }
+  spec {
+    max_unavailable = 1
+    selector {
+      match_labels = {
+        k8s-app = "kube-dns"
+      }
+    }
+  }
+}
+
+
+resource "kubernetes_pod_disruption_budget" "konnectivity-agent" {
+  depends_on  = [module.gke]
+  metadata {
+    name      = "k8s-pdb-konnectivity-agent"
+    namespace = "kube-system"
+  }
+  spec {
+    max_unavailable = "50%"
+    selector {
+      match_labels = {
+        k8s-app = "konnectivity-agent"
+      }
+    }
+  }
+}
+
+


### PR DESCRIPTION
* Added K8s pod disruption budget to allow eviciting pods related to kube-system workloads (kube-dns, konnectivity-agent)
* Increased linux pool basic machine type to e2-highcpu-2, to allow eviction of pods to the one node 