### PR TITLE
Added support for Dockerhub credentials for pulling private images

### DIFF
--- a/config.tfvars
+++ b/config.tfvars
@@ -1,44 +1,44 @@
 #### Required ####
 
-# GCP Project ID
-project_id = ""
-# The name you wish to have as a prefix for the deployment's resources. Must comply with [a-z]([-a-z0-9]*[a-z0-9])
-infra_name = "scallops"
+project_id = ""          # GCP Project ID
+infra_name = "scallops"  # The name you wish to have as a prefix for the deployment's resources. Must comply with [a-z]([-a-z0-9]*[a-z0-9])
 backups_bucket_name = "" # The name of an existing bucket you wish to receive backups to. Terraform will create the required permission to upload the backup archive.
 
-#### Optional ####
 
-# Office IP / home IPs
-operator_ips = []
+#### Optionals ####
+operator_ips = []   # Office IP / home IPs
 
 
+## External DNS ##
 # Uncomment below 3 lines if wishing to supply external DNS name for accessing Gitalb instance
+
 # external_hostname = "scallops.mydomain.com" # Requires re-deploy of the Gitlab instance to be set as external url from Gitlab's perspective. Will also update Certificate ALT names
-# dns_project_id = ""                 # The project ID where the managed DNS zone is located
-# dns_managed_zone_name = "mydomain-com"            # The configured managed DNS zone name
+# dns_project_id = ""                         # The project ID where the managed DNS zone is located
+# dns_managed_zone_name = "mydomain-com"      # The configured managed DNS zone name
 
 
-# Uncomment below 3 lines if wishing to supply external DNS name for accessing Gitalb instance
-#external_hostname = ""
-#dns_project_id = ""  # The project ID where the managed DNS zone is located
-#dns_managed_zone_name = "" # The configured managed DNS zone name
+## Docker hub credentials ##
+# An existing secret name storing Dockerhub credentials to fetch private container images (format is username:password or username:access-token).
+# Creating Dockerhub access token https://docs.docker.com/docker-hub/access-tokens/
+# Creating a secret through GCP secret manager https://cloud.google.com/secret-manager/docs/creating-and-accessing-secrets#create
+
+# dockerhub-creds-secret = ""     # Name of the secret in secret-manager
 
 
-# Default deployment values, uncommenct and modify only if needed (us-central-1 considered to be the cheapest).
 
-# The Gitlab instance Web server protocol, http or https.
-# gitlab_instance_protocol = "https" 
-# Zone for the k8s cluster, Gitlab instance and network.
-# zone = "a"
-# Region for the k8s cluster, Gitlab instance and network.
-# region = us-central-1 
+## Default deployment values ##
+# Uncommenct and modify only if needed (us-central-1 considered to be the cheapest).
+
+# gitlab_instance_protocol = "https"  # The Gitlab instance Web server protocol, http or https.
+# zone = "a"                          # Zone for the k8s cluster, Gitlab instance and network.
+# region = us-central-1               # Region for the k8s cluster, Gitlab instance and network.
 
 
 
 
 ## Migration variables ##
-## If you plan on migrating from a different gitlab instance, uncomment all migration variables below, and follow requirements.
-### *Requires Gsutil as backup will be downloaded locally
+# If you plan on migrating from a different gitlab instance, uncomment all migration variables below, and follow requirements.
+# Requires Gsutil on the terraform deployer system as backup will be downloaded locally
 
 # migrate_gitlab = true                   ## If performing migration from another Gitlab instance and got a backup file from previous instance. true/false.
 # migrate_gitlab_version = ""             ## The Gitlab full version that you are migrating from e.g. '14.3.3-ee'

--- a/gitlab-runner/dockerhub-values.yaml
+++ b/gitlab-runner/dockerhub-values.yaml
@@ -1,0 +1,21 @@
+rbac:
+ create: true
+ rules:
+ - resources: ["pods", "secrets", "configmaps", "pods/attach", "pods/exec"]
+   verbs: ["*"]
+runners:
+  imagePullPolicy: always
+  protected: true
+  tags: "dockerhub,kubernetes"
+  config: |
+    [[runners]]
+      executor = "kubernetes"
+      shell = "bash"
+      
+      [runners.kubernetes.node_selector]
+        "node_pool" = "linux-pool"
+
+      [runners.kubernetes]
+        namespace = "sensitive"
+        poll_interval = 30
+        poll_timeout = 3600

--- a/gke.tf
+++ b/gke.tf
@@ -45,6 +45,26 @@ resource "kubernetes_secret" "k8s_gitlab_cert_secret-sensitive" {
   }
 }
 
+resource "kubernetes_secret" "dockerhub-creds-config" {
+  depends_on  = [module.gke_auth, module.gke, kubernetes_namespace.sensitive-namespace]
+  count       = var.dockerhub-creds-secret != "" ? 1 : 0  
+  data        = {
+    ".dockerconfigjson" =  jsonencode({
+                auths = {
+                        "https://index.docker.io/v1/" = {
+                            auth = "${base64encode("${data.google_secret_manager_secret_version.dockerhub-secret[0].secret_data}")}"
+                    }
+                }
+    })
+  }
+  type        = "kubernetes.io/dockerconfigjson"
+  metadata {
+    name      = "dockerhub-creds-jsonconfig"
+    namespace = "sensitive"
+  }
+}
+
+
 ## K8s auth
 
 module "gke_auth" {

--- a/secrets.tf
+++ b/secrets.tf
@@ -197,3 +197,12 @@ resource "google_secret_manager_secret_version" "gitlab_backup_key" {
   secret      = google_secret_manager_secret.gitlab_backup_key.id
   secret_data = random_password.gitlab_backup_key.result
 }
+
+
+# Docker hub credentials secret
+
+data "google_secret_manager_secret_version" "dockerhub-secret" {
+  provider  = google.offensive-pipeline
+  count     = var.dockerhub-creds-secret != "" ? 1 : 0
+  secret    = var.dockerhub-creds-secret
+}

--- a/vars.tf
+++ b/vars.tf
@@ -147,3 +147,8 @@ variable "dns_record_ttl" {
   default     = 300
 }
 
+variable "dockerhub-creds-secret" {
+  description = "An existing secret name in the same GCP project storing the Dockerhub credentials (username:password)"
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
**Optional feature**
* Deployer can supply secret manager name (to dockerhub-creds-secret variable) where he is storing his docker hub credentials using the user:password format.
* TF creates and adds additional K8s secret on the sensitive namespace with the docker json config structure
* TF adds additional Gitlab runner on the sensitive namespace that is allowed to use the Dockerhub credentials and pull private container images.

