### PR TITLE
Remove API token seeding and usage

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -132,14 +132,6 @@ resource "google_secret_manager_secret_iam_binding" "gitlab_initial_root_pwd" {
   ]
 }
 
-resource "google_secret_manager_secret_iam_binding" "gitlab_api_token" {
-  project    = google_secret_manager_secret.gitlab_api_token.project
-  secret_id  = google_secret_manager_secret.gitlab_api_token.secret_id
-  role       = "roles/secretmanager.secretAccessor"
-  members    = [
-    "serviceAccount:${google_service_account.gitlab_service_account.email}",
-  ]
-}
 
 resource "google_secret_manager_secret_iam_binding" "gitlab_backup_key" {
   project    = google_secret_manager_secret.gitlab_backup_key.project

--- a/main.tf
+++ b/main.tf
@@ -6,7 +6,6 @@ resource "google_compute_instance" "gitlab" {
                   google_secret_manager_secret_version.gitlab-self-signed-cert-key-version,
                   google_secret_manager_secret_version.gitlab_initial_root_pwd,
                   google_secret_manager_secret_version.gitlab_runner_registration_token,
-                  google_secret_manager_secret_version.gitlab_api_token
                   ]
   provider     = google.offensive-pipeline
   name         = "${var.infra_name}-gitlab"
@@ -45,7 +44,6 @@ resource "google_compute_instance" "gitlab" {
     instance-external-domain        = var.external_hostname != "" ? var.external_hostname : local.instance_internal_domain
     instance-protocol               = var.gitlab_instance_protocol
     gitlab-initial-root-pwd-secret	= google_secret_manager_secret.gitlab_initial_root_pwd.secret_id
-    gitlab-api-token-secret         = google_secret_manager_secret.gitlab_api_token.secret_id
     gitlab-cert-key-secret         	= google_secret_manager_secret.gitlab-self-signed-cert-key.secret_id
     gitlab-cert-public-secret	    = google_secret_manager_secret.gitlab-self-signed-cert-crt.secret_id
     gitlab-ci-runner-registration-token-secret = google_secret_manager_secret.gitlab_runner_registration_token.secret_id

--- a/outputs.tf
+++ b/outputs.tf
@@ -9,8 +9,3 @@ output "gitlab_root_password_secret" {
   description = "Secret name where Gitlab (Web UI) root account's password is stored"
   value       = google_secret_manager_secret.gitlab_initial_root_pwd.secret_id
 }
-
-output "gitlab_api_access_secret" {
-  description = "Secret Name where Gitlab API access key stored, and need to be set at Gitlab Instance level"
-  value       = google_secret_manager_secret.gitlab_api_token.secret_id
-}

--- a/secrets.tf
+++ b/secrets.tf
@@ -92,12 +92,6 @@ resource "random_password" "gitlab_initial_root_pwd" {
   override_special = "-_"
 }
 
-resource "random_password" "gitlab_api_token" {
-  length           = 20
-  special          = true
-  override_special = "-_"
-}
-
 resource "random_password" "gitlab_backup_key" {
   length           = 24
   special          = true
@@ -148,30 +142,6 @@ resource "google_secret_manager_secret" "gitlab_initial_root_pwd" {
 resource "google_secret_manager_secret_version" "gitlab_initial_root_pwd" {
   secret      = google_secret_manager_secret.gitlab_initial_root_pwd.id
   secret_data = random_password.gitlab_initial_root_pwd.result
-}
-
-
-# Gitlab root account personal access token (API)
-
-resource "google_secret_manager_secret" "gitlab_api_token" {
-  provider   = google.offensive-pipeline
-  secret_id  = "${var.infra_name}-gitlab-api-token"
-  labels     = {
-          label = "gitlab"
-  }
-  replication {
-    user_managed {
-          replicas {
-            location = var.region
-      }
-    }
-  }
-}
-
-
-resource "google_secret_manager_secret_version" "gitlab_api_token" {
-  secret      = google_secret_manager_secret.gitlab_api_token.id
-  secret_data = random_password.gitlab_api_token.result
 }
 
 


### PR DESCRIPTION
* Remove TF resources related to the creation and seeding of Gitlab api key
* Removed resource references
* Removed api key as output
* Modified bash startup scripts interaction with Gitlab to be  through Rails console instead of API
* Auto adding internal hostname URLs to the instance level variables, so the pipeline jobs will be able to resolve the instance internal IP and communicate internally
* Now installing specific gitlab version instead of latest