### PR TITLE
Checking if external DNS name supplied

### DIFF
--- a/secrets.tf
+++ b/secrets.tf
@@ -17,11 +17,12 @@ resource "tls_self_signed_cert" "gitlab-self-signed-cert" {
     organization        = "Company"
   }
   
-  dns_names             = [
-                           "${var.infra_name}-gitlab.local",
-                           local.instance_internal_domain,
-                           var.external_hostname
-                           ]
+  dns_names             = flatten([
+                            "${var.infra_name}-gitlab.local",
+                            local.instance_internal_domain,
+                            var.external_hostname != "" ? [var.external_hostname] : []
+                            ])
+                           
   ip_addresses          = ["10.0.0.2"]
   validity_period_hours = 87600 //Certificate will be valid for 10 years 
 


### PR DESCRIPTION
Bug:
Certificate generation errored due to empty external hostname that takes place when not supplied by the user.